### PR TITLE
Add cacert support and clean up 'meta' prod directory so it isn't meta/meta

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -51,13 +51,20 @@ zopen_check_results()
 zopen_install()
 {
   set -e
-  mkdir -p $ZOPEN_INSTALL_DIR
-  rm -rf $PWD/zotsampleport
-  cp -r $PWD/ $ZOPEN_INSTALL_DIR/
+  mkdir -p "$ZOPEN_INSTALL_DIR"
+  rm -rf "$PWD/zotsampleport"
+  cp -r "$PWD/" "$ZOPEN_INSTALL_DIR/"
   set +e
 }
 
 zopen_append_to_env()
 {
-  echo "export SSL_CERT_FILE=\"\$PWD/cacert.pem\""
+  echo "export SSL_CERT_FILE=\"\$PWD/../cacert.pem\""
+}
+
+
+zopen_append_to_setup() {
+cat <<EOF
+rm -rf "\$PWD/meta/.git"* "\$PWD/meta/.editorconfig" "\$PWD/meta/.env" && cp -r "\$PWD/meta/." "\$PWD/" && rm -rf "\$PWD/meta" && cp "\$PWD/cacert.pem" "\$PWD/../cacert.pem"
+EOF
 }


### PR DESCRIPTION
install meta and copy pem file to parent directory for other tools (git, curl, openssl) to be able to use.

This requires 'meta' to first be built since it uses new function 'zopen_append_to_setup'