### PR TITLE
basic changes to enable us to write new test cases for zopen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ log/
 log.DEV/
 meta*/
 install/
+work/

--- a/buildenv
+++ b/buildenv
@@ -15,6 +15,7 @@ zopen_init()
 zopen_check()
 {
   WORK_DIR="${ZOPEN_ROOT}/work"
+  mkdir -p "${WORK_DIR}"
 
   #
   # Set up environment

--- a/buildenv
+++ b/buildenv
@@ -14,26 +14,23 @@ zopen_init()
 
 zopen_check()
 {
-  # Test zopen with zotsampleport:
-  . ./.env
+  WORK_DIR="${ZOPEN_ROOT}/work"
+
+  #
+  # Set up environment
+  #
+  . ${ZOPEN_ROOT}/meta/.env
 
   # Avoid inheriting this buildenv's environment variables
   unset ZOPEN_CHECK
   unset ZOPEN_MAKE
   unset ZOPEN_CONFIGURE
 
-  # Use a local install dir
-  OLD_INSTALL_DIR=$ZOPEN_INSTALL_DIR
-  ZOPEN_INSTALL_DIR=$PWD/zotsampleport/install
-
-  git clone https://github.com/ZOSOpenTools/zotsampleport.git
-  cd zotsampleport
-
-  zopen build -v
-
-  # Set ZOPEN_INSTALL_DIR back to the original
-  ZOPEN_INSTALL_DIR=$OLD_INSTALL_DIR
-  cd -
+  for test in ${ZOPEN_ROOT}/tests/zopen_check_* ; do
+    if "${test}" "${WORK_DIR}" ; then
+      return 1
+    fi
+  done
 }
 
 zopen_check_results()

--- a/buildenv
+++ b/buildenv
@@ -22,16 +22,18 @@ zopen_check()
   #
   . ${ZOPEN_ROOT}/meta/.env
 
-  # Avoid inheriting this buildenv's environment variables
-  unset ZOPEN_CHECK
-  unset ZOPEN_MAKE
-  unset ZOPEN_CONFIGURE
-
-  for test in ${ZOPEN_ROOT}/tests/zopen_check_* ; do
-    if "${test}" "${WORK_DIR}" ; then
-      return 1
+  checks=${ZOPEN_ROOT}/tests/zopen_check_*
+  echo $checks
+  for check in $checks ; do
+    "${check}" "${WORK_DIR}"
+    rc=$?
+    if [ ${rc} -gt 0 ]; then
+      echo "FAIL: ${check}"
+    else
+      echo "PASS: ${check}"
     fi
   done
+  return 0
 }
 
 zopen_check_results()
@@ -40,10 +42,10 @@ zopen_check_results()
   pfx="$2"
   chk="$1/$2_check.log"
 
-  grep -q "Test results: 1 tests pass out of 1 tests" $chk
-  failures=$?
-  echo "actualFailures:$failures"
-  echo "totalTests:1"
+  pass=$( cat "${chk}" | grep -E '^PASS: ' | wc -l)
+  fail=$( cat "${chk}" | grep -E '^FAIL: ' | wc -l)
+  echo "actualFailures:$fail"
+  echo "totalTests:$(( pass+fail ))"
   echo "expectedFailures:0"
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+## Test cases for zopen
+
+## To add a new testcase:
+
+- create an executable (e.g. shell script) with a name of zopen_check_xxx where xxx is the name you want to use
+- the executable should take one parameter which is the working directory it can use. If successful, it should clean up after itself
+- the executable should exit with 0 if successful, non-zero otherwise

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -8,26 +8,20 @@ set -e # hard failure if any commands fail
 
 WORKDIR="$1"
 
-cd "${WORKDIR}"
-
 # Use a local install dir
-ZOPEN_INSTALL_DIR=$WORKDIR/zotsampleport-install
+SAMPLE_PORT_DIR="${WORKDIR}/zotsampleport"
+ZOPEN_INSTALL_DIR="${WORKDIR}/zotsampleport-install"
 
-rm -rf "${ZOPEN_INSTALL_DIR}" 
-rm -rf zotsampleport 
+rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 
 mkdir -p "${ZOPEN_INSTALL_DIR}"
-mkdir zotsampleport
+mkdir -p "${SAMPLE_PORT_DIR}"
 
-git clone https://github.com/ZOSOpenTools/zotsampleport.git
+( cd "${WORKDIR}" && git clone https://github.com/ZOSOpenTools/zotsampleport.git )
 
-cd zotsampleport
+( cd "${SAMPLE_PORT_DIR}" && zopen build -v )
 
-zopen build -v 
-
-cd "${WORKDIR}"
-
-rm -rf zotsampleport
+rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 
 exit 0
 

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -3,9 +3,8 @@
 #
 # Basic 'zopen build' test using zotsampleport
 #
-set -x
 set -e # hard failure if any commands fail
-
+set -x
 WORKDIR="$1"
 
 # Use a local install dir
@@ -18,6 +17,12 @@ mkdir -p "${ZOPEN_INSTALL_DIR}"
 mkdir -p "${SAMPLE_PORT_DIR}"
 
 ( cd "${WORKDIR}" && git clone https://github.com/ZOSOpenTools/zotsampleport.git )
+
+
+  # Avoid inheriting this buildenv's environment variables
+
+  set | grep ZOPEN_
+  exit 0
 
 ( cd "${SAMPLE_PORT_DIR}" && zopen build -v )
 

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+#
+# Basic 'zopen build' test using zotsampleport
+#
+set -x
+set -e # hard failure if any commands fail
+
+WORKDIR="$1"
+
+cd "${WORKDIR}"
+
+# Use a local install dir
+ZOPEN_INSTALL_DIR=$WORKDIR/zotsampleport-install
+
+rm -rf "${ZOPEN_INSTALL_DIR}" 
+rm -rf zotsampleport 
+
+mkdir -p "${ZOPEN_INSTALL_DIR}"
+mkdir zotsampleport
+
+git clone https://github.com/ZOSOpenTools/zotsampleport.git
+
+cd zotsampleport
+
+zopen build -v 
+
+cd "${WORKDIR}"
+
+rm -rf zotsampleport
+
+exit 0
+

--- a/tests/zopen_check_version
+++ b/tests/zopen_check_version
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#
+# Basic 'zopen version' check for all tools in 'bin'
+#
+set -e # hard failure if any commands fail
+set -x
+WORKDIR="$1"
+zopen_tool_binary=`whence zopen`
+
+exit 0
+

--- a/tests/zopen_check_version
+++ b/tests/zopen_check_version
@@ -7,6 +7,19 @@ set -e # hard failure if any commands fail
 set -x
 WORKDIR="$1"
 zopen_tool_binary=`whence zopen`
+zopen_tool_directory=$( dirname ${zopen_tool_binary} )
+
+#
+# msf - this should be all tools of the pattern zopen-* but that would break this test right now
+# 
+tools="zopen-init zopen-build zopen-install zopen-generate zopen-query zopen-remove zopen-alt zopen-clean"
+for zopen_tool in $tools; do
+  "${zopen_tool}" --version >/dev/null 
+  if [ $? -gt 0 ]; then
+    echo "${zopen_tool} has not implemented --version option" >&2
+    exit 4
+  fi
+done
 
 exit 0
 


### PR DESCRIPTION
light-weight test framework that lets people independently add tests of the form zopen_check_xxx to the test suite.

Moved 'zopen_check_build' code into it's own testcase as a 'sample' and created a simple README