### PR TITLE
Make it easy to test a development 'meta'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 log/
 log.DEV/
-meta*/
+meta/
+meta
 install/
 work/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-meta
+metaport
 
-A set of utilities for z/OS Open Tools
+A test validation of our 'meta' tools. 
+metaport MUST be run before any code in 'meta' repo can be merged into main
+
+By default, metaport will pull down the latest 'meta' repo.
+To test against your local development repo, do the following:
+
+Export ZOPEN_META_DEV_ROOT to the root of your cloned git 'meta' repo, e.g
+```
+export ZOPEN_META_DEV_ROOT=$HOME/zopen/dev/meta/
+```
+
+Change directory to your 'metaport' repo, e.g.
+```
+cd $HOME/zopen/dev/metaport
+```
+
+Perform zopen build and validate that the tests all run correctly against your local build, e.g.
+```
+zopen build
+```
+
+Note that running `zopen build` against your development repo will NOT install the code into your
+environment.
+

--- a/buildenv
+++ b/buildenv
@@ -11,7 +11,7 @@ if [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
   if [ -d "${META_DEV_DIR}" ]; then
     if [ -L "${META_DEV_DIR}" ]; then
       echo "ZOPEN_META_DEV_ROOT is NOT set, but ${META_DEV_DIR} is a symbolic link. Either set ZOPEN_META_DEV_ROOT or remove the symbolic link"
-      return 8
+      exit 8
     fi
   fi
   export ZOPEN_INSTALL="zopen_install"
@@ -21,14 +21,14 @@ else
 
   if ! [ -d "${ZOPEN_META_DEV_ROOT}" ] ; then
     echo "ZOPEN_META_DEV_ROOT points to ${ZOPEN_META_DEV_ROOT}, but the directory does not exist" >&2
-    return 8
+    exit 8
   fi
 
   # Set up our own 'meta' to use from our dev code and skip install
   basename=$(basename "${ZOPEN_META_DEV_ROOT}")
   if [ "x${basename}" != "xmeta" ]; then
     echo "ZOPEN_META_DEV_ROOT should point to a 'meta' cloned directory. It is: ${ZOPEN_META_DEV_ROOT}" >&2
-    return 8
+    exit 8
   fi
 
   if [ -d "${META_DEV_DIR}" ]; then
@@ -46,7 +46,7 @@ else
       
   if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DEV_DIR}" ; then
     echo "Unable to create symbolic from from ${META_DEV_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
-    return 8
+    exit 8
   fi
 fi
 

--- a/buildenv
+++ b/buildenv
@@ -8,6 +8,12 @@ export ZOPEN_CHECK="zopen_check"
 export ZOPEN_INSTALL="zopen_install"
 
 if ! [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
+
+  if ! [ -d "${ZOPEN_META_DEV_ROOT}" ] ; then
+    echo "ZOPEN_META_DEV_ROOT points to ${ZOPEN_META_DEV_ROOT}, but the directory does not exist" >&2
+    return 8
+  fi
+
   # Do not install this code - just test it
   export ZOPEN_INSTALL=skip
 
@@ -28,8 +34,8 @@ if ! [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
       rm "${META_DIR}"
     fi
   else
-    echo "${META_DIR} should be a directory or symbolic link pointing to a directory. It is neither" >&2
-    return 8
+    # Directory has not yet been cloned - just have symbolic link created (next)
+    :
   fi
       
   if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DIR}" ; then
@@ -41,6 +47,16 @@ fi
 zopen_init()
 {
   export PATH="$PWD/bin:$PATH"
+
+  myzopen=$( whence zopen )
+  if [ $? -gt 0 ]; then
+    echo "Error - unable to find zopen in the PATH" >&2
+    return 8
+  fi
+  if [ "${myzopen}" != "${PWD}/bin/zopen" ]; then
+    echo "Error - unable to find local zopen at ${PWD}/bin/zopen" >&2
+    return 8
+  fi
 }
 
 zopen_check()

--- a/buildenv
+++ b/buildenv
@@ -7,6 +7,37 @@ export ZOPEN_MAKE="skip"
 export ZOPEN_CHECK="zopen_check"
 export ZOPEN_INSTALL="zopen_install"
 
+if ! [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
+  # Do not install this code - just test it
+  export ZOPEN_INSTALL=skip
+
+  # Set up our own 'meta' to use from our dev code and skip install
+  basename=$(basename "${ZOPEN_META_DEV_ROOT}")
+  if [ "x${basename}" != "xmeta" ]; then
+    echo "ZOPEN_META_DEV_ROOT should point to a 'meta' cloned directory. It is: ${ZOPEN_META_DEV_ROOT}" >&2
+    return 8
+  fi
+
+  META_DIR="${PWD}/meta"
+  if [ -d "${META_DIR}" ]; then
+    if ! [ -L "${META_DIR}" ]; then
+      # We may already have a git clone'd meta. If so, move the cloned tree to meta-cloned
+      mv "${META_DIR}" "${META_DIR}-cloned"
+    else
+      # There may already be a symbolic link here - if so, delete it in case it is stale
+      rm "${META_DIR}"
+    fi
+  else
+    echo "${META_DIR} should be a directory or symbolic link pointing to a directory. It is neither" >&2
+    return 8
+  fi
+      
+  if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DIR}" ; then
+    echo "Unable to create symbolic from from ${META_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
+    return 8
+  fi
+fi
+
 zopen_init()
 {
   export PATH="$PWD/bin:$PATH"

--- a/buildenv
+++ b/buildenv
@@ -5,17 +5,17 @@ export ZOPEN_GIT_DEPS="git gzip make tar zoslib"
 export ZOPEN_CONFIGURE="skip"
 export ZOPEN_MAKE="skip"
 export ZOPEN_CHECK="zopen_check"
-export ZOPEN_INSTALL="zopen_install"
 
-if ! [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
+if [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
+  export ZOPEN_INSTALL="zopen_install"
+else
+  export ZOPEN_INSTALL='skip'
+  echo "Installation will not be performed - testing dev environment"
 
   if ! [ -d "${ZOPEN_META_DEV_ROOT}" ] ; then
     echo "ZOPEN_META_DEV_ROOT points to ${ZOPEN_META_DEV_ROOT}, but the directory does not exist" >&2
     return 8
   fi
-
-  # Do not install this code - just test it
-  export ZOPEN_INSTALL=skip
 
   # Set up our own 'meta' to use from our dev code and skip install
   basename=$(basename "${ZOPEN_META_DEV_ROOT}")

--- a/buildenv
+++ b/buildenv
@@ -45,7 +45,7 @@ else
   fi
       
   if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DEV_DIR}" ; then
-    echo "Unable to create symbolic from from ${META_DEV_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
+    echo "Unable to create symbolic from ${META_DEV_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
     exit 8
   fi
 fi

--- a/buildenv
+++ b/buildenv
@@ -6,7 +6,14 @@ export ZOPEN_CONFIGURE="skip"
 export ZOPEN_MAKE="skip"
 export ZOPEN_CHECK="zopen_check"
 
+META_DEV_DIR="${PWD}/meta"
 if [ -z "${ZOPEN_META_DEV_ROOT}" ] ; then
+  if [ -d "${META_DEV_DIR}" ]; then
+    if [ -L "${META_DEV_DIR}" ]; then
+      echo "ZOPEN_META_DEV_ROOT is NOT set, but ${META_DEV_DIR} is a symbolic link. Either set ZOPEN_META_DEV_ROOT or remove the symbolic link"
+      return 8
+    fi
+  fi
   export ZOPEN_INSTALL="zopen_install"
 else
   export ZOPEN_INSTALL='skip'
@@ -24,22 +31,21 @@ else
     return 8
   fi
 
-  META_DIR="${PWD}/meta"
-  if [ -d "${META_DIR}" ]; then
-    if ! [ -L "${META_DIR}" ]; then
+  if [ -d "${META_DEV_DIR}" ]; then
+    if ! [ -L "${META_DEV_DIR}" ]; then
       # We may already have a git clone'd meta. If so, move the cloned tree to meta-cloned
-      mv "${META_DIR}" "${META_DIR}-cloned"
+      mv "${META_DEV_DIR}" "${META_DEV_DIR}-cloned"
     else
       # There may already be a symbolic link here - if so, delete it in case it is stale
-      rm "${META_DIR}"
+      rm "${META_DEV_DIR}"
     fi
   else
     # Directory has not yet been cloned - just have symbolic link created (next)
     :
   fi
       
-  if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DIR}" ; then
-    echo "Unable to create symbolic from from ${META_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
+  if ! ln -s "${ZOPEN_META_DEV_ROOT}" "${META_DEV_DIR}" ; then
+    echo "Unable to create symbolic from from ${META_DEV_DIR} to ${ZOPEN_META_DEV_ROOT}" >&2
     return 8
   fi
 fi

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -16,9 +16,9 @@ mkdir -p "${ZOPEN_INSTALL_DIR}"
 mkdir -p "${SAMPLE_PORT_DIR}"
 
 ( cd "${WORKDIR}" && git clone https://github.com/ZOSOpenTools/zotsampleport.git )
-exit 0
 
-( cd "${SAMPLE_PORT_DIR}" && zopen build -v )
+( cd "${SAMPLE_PORT_DIR}" && exec zopen build -v )
+exit 0
 
 rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 


### PR DESCRIPTION
This PR enhances the build and test process so that you can optionally point to your local 'dev' meta 
rather than run against the latest code in 'main'.
This ensures that we can validate code in 'meta' before merging it.

See the README.md for details. 