### PR TITLE
Get zopen_check_build running properly again

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,6 +1,6 @@
 export ZOPEN_GIT_URL="https://github.com/ZOSOpenTools/meta.git"
 export ZOPEN_TYPE="GIT"
-export ZOPEN_GIT_DEPS="git gzip make tar zoslib"
+export ZOPEN_GIT_DEPS="git gzip make tar bash zoslib"
 
 export ZOPEN_CONFIGURE="skip"
 export ZOPEN_MAKE="skip"

--- a/tests/include/zopen_check_services
+++ b/tests/include/zopen_check_services
@@ -1,0 +1,41 @@
+#
+# Meant to be sourced - provides services to be shared across zopen_check_xxx routines
+#
+
+zopen_save_and_clear()
+{
+  entries=$( set | grep -E '^ZOPEN_')
+  OLDIFS="$IFS"
+  IFS=$'\n'
+  for entry in $entries; do
+    val=${entry#*=}
+    key=${entry%%=*}
+    save_cmd='export ${key}_SAVE=${val}'
+    eval $save_cmd
+    clear_cmd='unset ${key}'
+    eval $clear_cmd
+  done
+  IFS="$OLDIFS"
+}
+
+zopen_clear_and_restore()
+{
+  entries=$( set | grep -E '^ZOPEN_')
+  OLDIFS="$IFS"
+  IFS=$'\n'
+  for entry in $entries; do
+    val=${entry#*=}
+    key=${entry%%=*}
+    origkey=${key%%_SAVE}
+    if [ "${origkey}" != "${key}" ]; then
+      restore_cmd='export ${origkey}=${val}'
+      eval $restore_cmd
+      clear_cmd='unset ${key}'
+      eval $clear_cmd
+    fi
+  done
+  IFS="$OLDIFS"
+}
+
+
+

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -1,14 +1,30 @@
-#!/bin/sh
+#!/bin/env bash
 
 #
-# Basic 'zopen build' test using zotsampleport
+# Basic 'zopen build' test using zotsampleport (note this REQUIRES bash)
 #
 set -e # hard failure if any commands fail
 WORKDIR="$1"
 
+ME=$(basename $0)
+MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
+
+. "${MYDIR}/include/zopen_check_services"
+
+zopen_save_and_clear
+
 # Use a local install dir
-SAMPLE_PORT_DIR="${WORKDIR}/zotsampleport"
-ZOPEN_INSTALL_DIR="${WORKDIR}/zotsampleport-install"
+export SAMPLE_PORT_DIR="${WORKDIR}/zotsampleport"
+export ZOPEN_INSTALL_DIR="${WORKDIR}/zotsampleport-install"
+export ZOPEN_DONT_PROCESS_CONFIG=true
+
+# Set up environment variables needed for 'build'
+export PATH="${MYDIR}/../meta/bin:${PATH}"
+export ZOPEN_CA="$ZOPEN_CA_SAVE"
+export ZOPEN_ROOTFS="$ZOPEN_ROOTFS_SAVE"
+export ZOPEN_SEARCH_PATH="$ZOPEN_SEARCH_PATH_SAVE"
+export ZOPEN_LOG_PATH="$ZOPEN_LOG_PATH_SAVE"
+export ZOPEN_PKGINSTALL="$ZOPEN_PKGINSTALL_SAVE"
 
 rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 
@@ -16,11 +32,12 @@ mkdir -p "${ZOPEN_INSTALL_DIR}"
 mkdir -p "${SAMPLE_PORT_DIR}"
 
 ( cd "${WORKDIR}" && git clone https://github.com/ZOSOpenTools/zotsampleport.git )
-exit 0
 
 ( cd "${SAMPLE_PORT_DIR}" && zopen build -v )
 
 rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
+
+zopen_clear_and_restore
 
 exit 0
 

--- a/tests/zopen_check_build
+++ b/tests/zopen_check_build
@@ -26,6 +26,13 @@ export ZOPEN_SEARCH_PATH="$ZOPEN_SEARCH_PATH_SAVE"
 export ZOPEN_LOG_PATH="$ZOPEN_LOG_PATH_SAVE"
 export ZOPEN_PKGINSTALL="$ZOPEN_PKGINSTALL_SAVE"
 
+if ! [ -z "${ZOPEN_ZOT_SAMPLEPORT_BRANCH_SAVE}" ]; then
+  zotsamplebranch="${ZOPEN_ZOT_SAMPLEPORT_BRANCH_SAVE}"
+  echo "Using ${zotsamplebranch} branch instead of default branch"
+else
+  zotsamplebranch="main"
+fi
+
 rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 
 mkdir -p "${ZOPEN_INSTALL_DIR}"
@@ -33,7 +40,7 @@ mkdir -p "${SAMPLE_PORT_DIR}"
 
 ( cd "${WORKDIR}" && git clone https://github.com/ZOSOpenTools/zotsampleport.git )
 
-( cd "${SAMPLE_PORT_DIR}" && zopen build -v )
+( cd "${SAMPLE_PORT_DIR}" && git checkout "${zotsamplebranch}" && zopen build -v )
 
 rm -rf "${ZOPEN_INSTALL_DIR}" "${WORKDIR}/zotsampleport"
 


### PR DESCRIPTION
Wrote code to save/restore ZOPEN_ variables so that zopen_build runs in a 'clean' environment.
Also set the required variables for zopen_build to properly function. 