### PR TITLE
Add in code to generate html in addition to man pages

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,6 +1,6 @@
 export ZOPEN_DEV_URL="https://github.com/ZOSOpenTools/meta.git"
 export ZOPEN_BUILD_LINE="DEV"
-export ZOPEN_DEV_DEPS="git gzip make tar bash zoslib help2man curl grep"
+export ZOPEN_DEV_DEPS="git gzip make tar bash zoslib help2man perl curl grep groff coreutils"
 
 export ZOPEN_CONFIGURE="skip"
 export ZOPEN_MAKE="skip"
@@ -105,12 +105,26 @@ zopen_check_results()
 zopen_install()
 {
   set -e
+  perlver=$(perl --version | head -2 | tail -1 | awk ' { print $4 }' | tr -d ',')
+  perlrel=$(perl --version | head -2 | tail -1 | awk ' { print $6 }' | tr -d ',')
+  if [ $perlver -lt 5 ] || [ $perlrel -lt 38 ]; then
+    echo "Wrong version of Perl: $perlver.$perlrel (expected 5.38 or higher)"
+    return 8
+  fi
   mkdir -p "$ZOPEN_INSTALL_DIR"
   rm -rvf "$PWD/zotsampleport"
   rm -rvf "$PWD/.git"* "$PWD/.editorconfig"
   cp -rv $PWD/* $ZOPEN_INSTALL_DIR/
   mkdir -p "$ZOPEN_INSTALL_DIR/man/man1"
   zopen-help2man "$ZOPEN_INSTALL_DIR/man/man1"
+  mkdir -p "$ZOPEN_INSTALL_DIR/ref"
+  echo "HTML reference pages will be written to $ZOPEN_INSTALL_DIR/ref"
+  for man in $ZOPEN_INSTALL_DIR/man/man1/*.1; do
+    base=${man##*/}
+    name=${base%%.1}
+    html="$ZOPEN_INSTALL_DIR/ref/${name}.html"
+    groff -m mandoc -Thtml -Wall "${man}" >"${html}"
+  done
   set +e
 }
 

--- a/tests/zopen_check_generate
+++ b/tests/zopen_check_generate
@@ -5,8 +5,8 @@
 #
 WORKDIR="$1"
 
-fillinprompts="
-ProjectNameTester
+fillinprompts="ProjectName
+Project Name Description
 mit
 https://github.com/stable/ProjectNameMaster.git
 make
@@ -16,4 +16,4 @@ stable
 bash
 "
 
-cd "${WORKDIR}" && echo "${fillinprompts}" | zopen-generate
+cd "${WORKDIR}" && echo "${fillinprompts}" | zopen-generate && rm -rf ProjectNameport

--- a/tests/zopen_check_man
+++ b/tests/zopen_check_man
@@ -7,7 +7,9 @@
 set -e # hard failure if any commands fail
 WORKDIR="$1"
 
-if ! zopen-help2man "${WORKDIR}" ; then
+rm -rf "${WORKDIR}/man1"
+mkdir -p "${WORKDIR}/man1"
+if ! zopen-help2man "${WORKDIR}/man1" ; then
   echo "zopen-help2man was unsuccessful in creating man files from the --help and --version options" >&2
   exit 4
 fi


### PR DESCRIPTION
Added in perl and coreutils. Neither should be required (perl should come in automatically from git and coreutils 'echo' should not be necessary but it was causing me grief). Added in groff because I use it on the install to generate html files
from man files.  If it's a concern, I can pull out perl and coreutils although it should be fine.

Added a check to 'install' to ensure we are using the right perl (and no some old perl that has issues).
Added an additional parameter to the generate test for the description (was this added?)

Clean up junk left behind after the generate test - otherwise it causes generate to be unhappy and prompts to clean up.

Create the man files under 'man1' so that you can look at the files under 'man' to see how they render without having to install the files

Finally - added the loop to run groff -m mandoc to generate html from man files.