### PR TITLE
Update test for zopen installation version

### DIFF
--- a/tests/zopen_check_basic_install
+++ b/tests/zopen_check_basic_install
@@ -148,9 +148,9 @@ if zopen install -y which=1.2.3.4.5; then
   fail "Attempt to install non-existent version of package did not fail"
 fi
 
-echo "Test versioned package [zopen install -y which=2.21.20231116_102257]"
-if ! zopen install -y which=2.21.20231116_102257; then
-  fail "Install of known available version (which 2.21.20231116_102257) failed"
+echo "Test versioned package [zopen install -y which=2.21.20241202_202927]"
+if ! zopen install -y which=2.21.20241202_202927; then
+  fail "Install of known available version (which 2.21.20241202_202927) failed"
 fi
 
 echo "Test odd versioning [zopen install -y =1.2.3.4]"


### PR DESCRIPTION
Update 2024 released version of which to test case, as releases prior to 2024 are ignored