### PR TITLE
Copy utilities from coreutils dependency instead of meta

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -90,22 +90,32 @@ zopen_init()
     return 8
   fi
 
-  # Download curl package if not present
+  # Download curl package
   CURL_PACKAGE="curl-8.10.1.20241001_214340.zos.pax.Z"
   CURL_URL="https://github.com/zopencommunity/curlport/releases/download/STABLE_curlport_2544/${CURL_PACKAGE}"
   mkdir -p "$PWD/packages"
   
-  # Check if any curl package already exists
-  existing_curl=$(ls "$PWD/packages"/curl-*.zos.pax.Z 2>/dev/null | head -1)
-  
-  if [ -n "$existing_curl" ]; then
-    echo "Found existing curl package: $(basename "$existing_curl"), skipping download"
+  echo "Downloading curl package from ${CURL_URL}..."
+  curl -L -o "$PWD/packages/${CURL_PACKAGE}" "${CURL_URL}" || {
+    echo "Error: Failed to download curl package"
+    return 1
+  }
+
+  # Copy date and sha256sum utilities from coreutils dependency
+  mkdir -p "$PWD/utilities"
+  if [ -n "$COREUTILS_HOME" ] && [ -d "$COREUTILS_HOME/bin" ]; then
+    for util in date sha256sum; do
+      # Try both regular and GNU-prefixed versions
+      if [ -f "$COREUTILS_HOME/bin/$util" ]; then
+        cp -v "$COREUTILS_HOME/bin/$util" "$PWD/utilities/"
+      elif [ -f "$COREUTILS_HOME/bin/g$util" ]; then
+        cp -v "$COREUTILS_HOME/bin/g$util" "$PWD/utilities/$util"
+      else
+        echo "Warning: $util (or g$util) not found in coreutils at $COREUTILS_HOME/bin"
+      fi
+    done
   else
-    echo "Downloading curl package from ${CURL_URL}..."
-    curl -L -o "$PWD/packages/${CURL_PACKAGE}" "${CURL_URL}" || {
-      echo "Error: Failed to download curl package"
-      return 1
-    }
+    echo "Warning: COREUTILS_HOME not set or coreutils bin directory not found"
   fi
 }
 
@@ -177,19 +187,11 @@ zopen_install()
   fi
 
   # Copy essential runtime folders
-  for folder in bin include man data utilities patch-utils; do
+  for folder in bin include man data utilities packages patch-utils; do
     if [ -d "$PWD/$folder" ]; then
       cp -rv "$PWD/$folder" "$ZOPEN_INSTALL_DIR/"
     fi
   done
-
-  # Copy only curl packages
-  if [ -d "$PWD/packages" ]; then
-    mkdir -p "$ZOPEN_INSTALL_DIR/packages"
-    for curl_pkg in "$PWD/packages"/curl-*.zos.pax.Z; do
-      [ -f "$curl_pkg" ] && cp -v "$curl_pkg" "$ZOPEN_INSTALL_DIR/packages/"
-    done
-  fi
 
   # Copy essential runtime files
   for file in .env cacert.pem LICENSE; do


### PR DESCRIPTION
- Modified zopen_init to copy date and sha256sum from COREUTILS_HOME/bin
- Support both regular and GNU-prefixed utility names (gdate, gsha256sum)
- Removed check for existing curl packages, always download
- Added packages folder to zopen_install copy loop
- Removed duplicate curl package copy logic